### PR TITLE
Fallback method to get friendly name for null columns in simple case

### DIFF
--- a/XrmToolBox.Controls/Controls/CRMGridView.cs
+++ b/XrmToolBox.Controls/Controls/CRMGridView.cs
@@ -657,6 +657,13 @@ namespace xrmtb.XrmToolBox.Controls
                 {
                     var dataColumn = new DataColumn(attribute);
                     dataColumn.Caption = attribute;
+
+                    if (!attribute.Contains(".") && showFriendlyNames)
+                    {
+                        var meta = MetadataHelper.GetAttribute(organizationService, entities.EntityName, attribute);
+
+                        dataColumn.Caption = meta?.DisplayName?.UserLocalizedLabel?.Label ?? attribute;
+                    }
                     columns.Add(dataColumn);
                 }
             }


### PR DESCRIPTION
Attempt to populate column friendly names for null columns, ref. #10 

This will work only for un-aliased columns from the primary entity. Aliased columns or columns from a link entity will still use the fallback column name of the raw attribute name.