### PR TITLE
Include primary key column in results if requested by ColumnOrder

### DIFF
--- a/XrmToolBox.Controls/Controls/CRMGridView.cs
+++ b/XrmToolBox.Controls/Controls/CRMGridView.cs
@@ -672,7 +672,7 @@ namespace xrmtb.XrmToolBox.Controls
             if (CreateColumnForAttribute(entities, attribute, force) is DataColumn dataColumn && dataColumn != null)
             {
                 var meta = dataColumn.ExtendedProperties.ContainsKey("Metadata") ? dataColumn.ExtendedProperties["Metadata"] as AttributeMetadata : null;
-                if (!force && meta?.IsPrimaryId == true)
+                if (meta?.IsPrimaryId == true && (!force || ShowIdColumn && meta.LogicalName == attribute))
                 {   // Never add column for primary key, it has a dedicated column
                     return;
                 }

--- a/XrmToolBox.Controls/Controls/CRMGridView.cs
+++ b/XrmToolBox.Controls/Controls/CRMGridView.cs
@@ -576,7 +576,7 @@ namespace xrmtb.XrmToolBox.Controls
                         .Select(a => a.Key)
                         .Distinct());
                 }
-                attributes.Distinct().ToList().ForEach(a => AddColumnForAttribute(entities, columns, a, showAllColumnsInColumnOrder));
+                attributes.Distinct().ToList().ForEach(a => AddColumnForAttribute(entities, columns, a, columnOrder.Contains(a) && (showAllColumnsInColumnOrder || entities.Any(e => e.Contains(a)))));
             }
             columns.Add(new DataColumn("#entity", typeof(Entity)));
             return columns;
@@ -672,7 +672,7 @@ namespace xrmtb.XrmToolBox.Controls
             if (CreateColumnForAttribute(entities, attribute, force) is DataColumn dataColumn && dataColumn != null)
             {
                 var meta = dataColumn.ExtendedProperties.ContainsKey("Metadata") ? dataColumn.ExtendedProperties["Metadata"] as AttributeMetadata : null;
-                if (meta?.IsPrimaryId == true)
+                if (!force && meta?.IsPrimaryId == true)
                 {   // Never add column for primary key, it has a dedicated column
                     return;
                 }

--- a/XrmToolBox.Controls/Controls/CRMGridView.cs
+++ b/XrmToolBox.Controls/Controls/CRMGridView.cs
@@ -576,7 +576,14 @@ namespace xrmtb.XrmToolBox.Controls
                         .Select(a => a.Key)
                         .Distinct());
                 }
-                attributes.Distinct().ToList().ForEach(a => AddColumnForAttribute(entities, columns, a, columnOrder.Contains(a) && (showAllColumnsInColumnOrder || entities.Any(e => e.Contains(a)))));
+                attributes.Distinct().ToList().ForEach(a =>
+                {
+                    // Force the column to be displayed if it's in the ColumnOrder list and we either want to display
+                    // all the listed columns or it contains data
+                    var force = columnOrder.Contains(a) && (showAllColumnsInColumnOrder || entities.Any(e => e.Contains(a)));
+
+                    AddColumnForAttribute(entities, columns, a, force);
+                });
             }
             columns.Add(new DataColumn("#entity", typeof(Entity)));
             return columns;
@@ -673,7 +680,12 @@ namespace xrmtb.XrmToolBox.Controls
             {
                 var meta = dataColumn.ExtendedProperties.ContainsKey("Metadata") ? dataColumn.ExtendedProperties["Metadata"] as AttributeMetadata : null;
                 if (meta?.IsPrimaryId == true && (!force || ShowIdColumn && meta.LogicalName == attribute))
-                {   // Never add column for primary key, it has a dedicated column
+                {
+                    // Don't show the primary key column twice. Ignore the primary key column if:
+                    // * `force` is false, i.e. the user isn't asking to see this column via the ColumnOrder property, OR
+                    // * The standard ID column is being already shown (via ShowIdColumn) and this isn't an aliased version
+                    //   An aliased column probably indicates an aggregate query and we want to show the aggregate (e.g. count)
+                    //   as a different column to the ID of the record.
                     return;
                 }
                 if (showFriendlyNames &&


### PR DESCRIPTION
Fixes https://github.com/rappen/FetchXMLBuilder/issues/294

Previously the primary key column would be excluded from the results as it is always included as a "special" column that can be shown or hidden using the `ShowIdColumn` property. Presumably this is a special-case override of the `ShowColumnsNotInColumnOrder` logic, as the primary key value is always returned and generally doesn't want to be shown.

If this column is specifically requested in the query however, the user does want to see it. This may be due to an aggregation as in this bug, but could also be because the user wants it for this query but either isn't aware of the separate property to show the ID column or doesn't want to generally enable it.

This change allows the primary key column to be shown when it is in the `ColumnOrder` property.